### PR TITLE
Improve R CMD check performance

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -42,5 +42,6 @@ jobs:
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           extra-packages: rcmdcheck
+          cache: R
 
       - uses: r-lib/actions/check-r-package@v2


### PR DESCRIPTION
## Summary
- cache package dependencies for R CMD check

## Testing
- `R CMD build . --no-build-vignettes --no-manual` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870886bc80083238e523871f7584187